### PR TITLE
Added depencies to INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -404,6 +404,7 @@ sudo apt-get install \
     qrencode \
     qt5-default \
     qttools5-dev-tools
+    qttools5-dev
 ```
 
 ### toxcore dependencies


### PR DESCRIPTION
Added "qttools5-dev" to the dependencies list for Ubuntu >16.04, without it you step upon the _"By not providing "FindQt5LinguistTools.cmake" in CMAKE_MODULE_PATH this project has asked CMake to find a package configuration file provided by "Qt5LinguistTools", but CMake did not find one."_ error